### PR TITLE
Fix - image height on small screens

### DIFF
--- a/src/components/DeveloperCard.vue
+++ b/src/components/DeveloperCard.vue
@@ -121,14 +121,13 @@ export default {
 
 <style lang="scss" scoped>
 
-
 .developer-card {
     border: 1px #ddd solid; 
     border-radius: 0.5rem;
     box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.03);
     transition: all ease .3s;
     width: 255px;
-    height: 100%;
+    height: auto;
     overflow: hidden;
     margin-right: 15px;
 
@@ -210,4 +209,23 @@ export default {
 .developer-card:last-child {
     margin-right: 0;
 }
+
+// Extra small devices (portrait phones, less than 576px)
+@media (max-width: 575.98px) { 
+    .developer-card {
+        &__image-cover {
+            height: 60vw;
+        }
+    }
+}
+
+// Medium devices (tablets, 768px and up)
+@media (min-width: 768px) and (max-width: 991.98px) {
+    .developer-card {
+        &__image-cover {
+            height: 30vw;
+        }
+    }
+}
+
 </style>


### PR DESCRIPTION
This pull request addresses the following issue https://github.com/VueDominicana/DominicanWhoCodes/issues/19. 

To achieve the solution, I used media queries to target _extra small (xs)_, and _medium (md)_ devices and assign specific viewport heights to the card's images.

Also, I notice that the card's heights were inconsistence, therefore, I modified the card's heights CSS property to be `height: auto`.

