### PR TITLE
Center the developers list

### DIFF
--- a/src/views/DevelopersList.vue
+++ b/src/views/DevelopersList.vue
@@ -46,5 +46,6 @@ export default {
   .developers-container {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
   }
 </style>


### PR DESCRIPTION
This pull request addresses the following issue https://github.com/VueDominicana/DominicanWhoCodes/issues/20. 

To achieve the solution, I added the flexbox property `justify-content: center` to the developer card's container.