### PR TITLE
Feature/responsive list

### DIFF
--- a/src/components/DeveloperCard.vue
+++ b/src/components/DeveloperCard.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="developer-card card mb-3">
+<div class="developer-card card">
     <div class="developer-card__image-container">
         <img class="developer-card__image-cover" :src="image" alt="developer image">
     </div>
@@ -126,10 +126,9 @@ export default {
     border-radius: 0.5rem;
     box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.03);
     transition: all ease .3s;
-    width: 255px;
+    width: 100%;
     height: auto;
     overflow: hidden;
-    margin-right: 15px;
 
     &:hover {
         transform: scale(1.02);

--- a/src/views/DevelopersList.vue
+++ b/src/views/DevelopersList.vue
@@ -44,7 +44,30 @@ export default {
 
 <style lang="scss" scope>
   .developers-container {
-    display: flex;
+    display: grid;
     flex-wrap: wrap;
+    grid-template-columns: repeat(4, 1fr);
+    grid-column-gap: 15px;
+    grid-row-gap: 15px;
+    justify-content: center;
+    transition: all ease .3s;
+  }
+
+  @media (min-width: 768px) and (max-width: 991.98px) {
+    .developers-container {
+      grid-template-columns: repeat(auto-fill, minmax(220px, 220px));
+    }
+  }
+
+  @media (min-width: 576px) and (max-width: 767px) {
+    .developers-container {
+      grid-template-columns: repeat(auto-fill, minmax(210px, 210px));
+    }
+  }
+
+  @media screen and (max-width: 575px) {
+    .developers-container {
+      grid-template-columns: 0.85fr;
+    }
   }
 </style>


### PR DESCRIPTION
This PR close #26 

- Use `CSS grid` since it allows us to take more control of width and gap between child elements (Developer Cards) and alignment

- Add media queries with the braking width used by @carlospgraciano in cards
